### PR TITLE
No longer need to re-save permalinks after plugin activation.

### DIFF
--- a/go-redirects.php
+++ b/go-redirects.php
@@ -26,6 +26,7 @@ if ( ! version_compare( PHP_VERSION, '5.4', '>=' ) ) {
 	add_action( 'admin_notices', 'gr_fail_wp_version' );
 } else {
 	include GR_PATH . 'includes/class-gr-plugin.php';
+	register_deactivation_hook(__FILE__, [$gr_plugin, 'deactivate']);
 }
 
 function gr_load_plugin_textdomain() {

--- a/includes/class-gr-plugin.php
+++ b/includes/class-gr-plugin.php
@@ -30,6 +30,8 @@ class GR_Plugin {
 
 		add_action( 'template_redirect', [ $this, 'do_redirect' ] );
 
+		add_action( 'wp_loaded', [ $this, 'refresh_permalinks'] );
+
 	}
 
 	public function include_vendor() {
@@ -259,8 +261,28 @@ class GR_Plugin {
 
 	}
 
+	/**
+	 * Refresh permalinks if is admin and no record of _gr_permalinks_refreshed
+	 */
+	public function refresh_permalinks() {
+		if (is_admin() && !get_option('_gr_permalinks_refreshed', false)) {
+
+			flush_rewrite_rules();
+			update_option('_gr_permalinks_refreshed', true);
+		}
+	}
+
+	/**
+	 * Plugin Deactivation Hook Function
+	 */
+	public function deactivate() {
+
+		delete_option('_gr_permalinks_refreshed');
+
+	}
+
 }
 
 endif;
 
-new GR_Plugin();
+$gr_plugin = new GR_Plugin();


### PR DESCRIPTION
These changes allows to remove part:

= I'm getting 404 errors when I try to visit my redirects. What do I do? =
Go to Settings → Permalinks and resave your permalink settings.